### PR TITLE
feat: add opt-in MCP methods and capability gating

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,21 @@ DZX_SOCKET=/tmp/dzx.sock dzx dev
 If your MCP client expects a specific protocol version, set it in `mcp.json`:
 ```
 {
-  "protocolVersion": "2025-06-18"
+  "protocolVersion": "2025-11-25"
+}
+```
+
+### Optional MCP Methods
+You can opt in to additional MCP methods in `mcp.json`:
+```
+{
+  "mcp": {
+    "methods": {
+      "resourcesTemplatesList": true,
+      "completionComplete": true,
+      "notificationsComplete": true
+    }
+  }
 }
 ```
 
@@ -137,6 +151,9 @@ Supported methods:
 - `resources/list`, `resources/read`, `resources/subscribe`, `resources/unsubscribe`
 - `prompts/list`, `prompts/get`
 - `logging/setLevel`, `notifications/cancelled`, `notifications/canceled`
+- Optional: `resources/templates/list`
+- Optional: `completion/complete`
+- Optional: `notifications/complete`, `notifications/completed`
 
 Streaming:
 - Add `?stream=1` or `Accept: text/event-stream` to get SSE (`event: message`).

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -21,7 +21,14 @@
   "version": "1.2.0",
   "runtime": "node",
   "entry": "src/server.ts",
-  "protocolVersion": "2025-06-18",
+  "protocolVersion": "2025-11-25",
+  "mcp": {
+    "methods": {
+      "resourcesTemplatesList": true,
+      "completionComplete": true,
+      "notificationsComplete": true
+    }
+  },
   "toolsDir": "tools",
   "resourcesDir": "resources",
   "promptsDir": "prompts",
@@ -67,6 +74,15 @@ Repo-relative path to your server entrypoint (usually `src/server.ts`).
 ### `protocolVersion` (optional)
 
 Override the MCP protocol version returned by `initialize`. Use this if your client expects a specific version string.
+
+### `mcp.methods` (optional)
+
+Opt-in flags for additional MCP methods.
+
+Fields:
+- `resourcesTemplatesList` (boolean) -- enables `resources/templates/list` and returns `{ "resourceTemplates": [] }`.
+- `completionComplete` (boolean) -- enables `completion/complete` and returns `{ "completion": { "values": [], "hasMore": false } }`.
+- `notificationsComplete` (boolean) -- accepts `notifications/complete` as a no-op notification.
 
 ### `toolsDir`, `resourcesDir`, `promptsDir` (optional)
 

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -28,6 +28,11 @@ dzx accepts both slash and dotted method names:
 - `logging/setLevel`
 - `notifications/cancelled`, `notifications/canceled`
 
+Optional methods (enable with `mcp.methods` in `mcp.json`):
+- `resources/templates/list`
+- `completion/complete`
+- `notifications/complete`, `notifications/completed`
+
 ## Calling tools
 
 Request:

--- a/mcp.schema.json
+++ b/mcp.schema.json
@@ -26,7 +26,36 @@
     },
     "protocolVersion": {
       "type": "string",
+      "default": "2025-11-25",
       "description": "Optional MCP protocol version override for initialize."
+    },
+    "mcp": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Optional MCP method feature flags.",
+      "properties": {
+        "methods": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "resourcesTemplatesList": {
+              "type": "boolean",
+              "default": false,
+              "description": "Enable resources/templates/list with an empty template list response."
+            },
+            "completionComplete": {
+              "type": "boolean",
+              "default": false,
+              "description": "Enable completion/complete with a deterministic empty completion response."
+            },
+            "notificationsComplete": {
+              "type": "boolean",
+              "default": false,
+              "description": "Accept notifications/complete as a no-op notification."
+            }
+          }
+        }
+      }
     },
     "toolsDir": {
       "type": "string",

--- a/src/core/manifest.ts
+++ b/src/core/manifest.ts
@@ -10,6 +10,19 @@ const ManifestSchema = z
     runtime: z.enum(["node", "deno"], { message: "runtime must be node or deno" }),
     entry: z.string().min(1, "entry must not be empty"),
     protocolVersion: z.string().optional(),
+    mcp: z
+      .object({
+        methods: z
+          .object({
+            resourcesTemplatesList: z.boolean().optional(),
+            completionComplete: z.boolean().optional(),
+            notificationsComplete: z.boolean().optional(),
+          })
+          .strict()
+          .optional(),
+      })
+      .strict()
+      .optional(),
     toolsDir: z.string().optional(),
     resourcesDir: z.string().optional(),
     promptsDir: z.string().optional(),

--- a/tests/features.test.mjs
+++ b/tests/features.test.mjs
@@ -56,6 +56,19 @@ test("Initialize includes tools", async () => {
   assert.ok(tools.length > 0, "tools should be included on initialize");
 });
 
+test("Initialize defaults to latest protocol version", async () => {
+  const client = await createTestServer({ cwd });
+  const resp = await client.server.processRequest(
+    JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {},
+    }),
+  );
+  assert.strictEqual(resp?.result?.protocolVersion, "2025-11-25");
+});
+
 test("Compatibility: dotted method names", async () => {
   const client = await createTestServer({ cwd });
   const resp = await client.server.processRequest(

--- a/tests/fixtures/mcp-optional-methods/mcp.json
+++ b/tests/fixtures/mcp-optional-methods/mcp.json
@@ -1,0 +1,13 @@
+{
+  "name": "mcp-optional-methods",
+  "version": "1.0.0",
+  "runtime": "node",
+  "entry": "src/server.js",
+  "mcp": {
+    "methods": {
+      "resourcesTemplatesList": true,
+      "completionComplete": true,
+      "notificationsComplete": true
+    }
+  }
+}

--- a/tests/fixtures/mcp-optional-methods/src/server.js
+++ b/tests/fixtures/mcp-optional-methods/src/server.js
@@ -1,0 +1,1 @@
+export default {};

--- a/tests/mcp-optional-methods.test.mjs
+++ b/tests/mcp-optional-methods.test.mjs
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import test from "node:test";
+import { createTestServer } from "../dist/testing/index.js";
+
+const defaultCwd = path.resolve(process.cwd(), "tests/fixtures/app-features");
+const enabledCwd = path.resolve(process.cwd(), "tests/fixtures/mcp-optional-methods");
+
+test("optional MCP methods are disabled by default", async () => {
+  const client = await createTestServer({ cwd: defaultCwd });
+
+  const initializeResp = await client.server.processRequest(
+    JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {},
+    }),
+  );
+  assert.equal(initializeResp?.result?.capabilities?.completions, undefined);
+
+  const templatesResp = await client.server.processRequest(
+    JSON.stringify({
+      jsonrpc: "2.0",
+      id: 2,
+      method: "resources/templates/list",
+      params: {},
+    }),
+  );
+  assert.equal(templatesResp?.error?.code, -32601);
+
+  const completionResp = await client.server.processRequest(
+    JSON.stringify({
+      jsonrpc: "2.0",
+      id: 3,
+      method: "completion/complete",
+      params: {},
+    }),
+  );
+  assert.equal(completionResp?.error?.code, -32601);
+});
+
+test("optional MCP methods can be enabled from manifest", async () => {
+  const client = await createTestServer({ cwd: enabledCwd });
+
+  const initializeResp = await client.server.processRequest(
+    JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {},
+    }),
+  );
+  assert.deepEqual(initializeResp?.result?.capabilities?.completions, {});
+
+  const templatesResp = await client.server.processRequest(
+    JSON.stringify({
+      jsonrpc: "2.0",
+      id: 2,
+      method: "resources/templates/list",
+      params: {},
+    }),
+  );
+  assert.deepEqual(templatesResp?.result, { resourceTemplates: [] });
+
+  const completionResp = await client.server.processRequest(
+    JSON.stringify({
+      jsonrpc: "2.0",
+      id: 3,
+      method: "completion/complete",
+      params: {
+        ref: {
+          type: "resource",
+          uri: "resource://anything",
+        },
+        argument: {
+          name: "query",
+          value: "abc",
+        },
+      },
+    }),
+  );
+  assert.deepEqual(completionResp?.result, {
+    completion: {
+      values: [],
+      hasMore: false,
+    },
+  });
+});
+
+test("notifications/complete is accepted as a no-op when enabled", async () => {
+  const client = await createTestServer({ cwd: enabledCwd });
+
+  const response = await client.server.processRequest(
+    JSON.stringify({
+      jsonrpc: "2.0",
+      method: "notifications/complete",
+      params: {},
+    }),
+  );
+  assert.equal(response, null);
+});

--- a/tests/runtime-schema.test.mjs
+++ b/tests/runtime-schema.test.mjs
@@ -23,3 +23,15 @@ test("validateSchema accepts valid output", async () => {
   const result = validateSchema(schema, { slug: "ok" });
   assert.equal(result.ok, true);
 });
+
+test("validateSchema rejects non-strict schema definitions", async () => {
+  const schema = {
+    type: "object",
+    properties: { slug: { type: "string" } },
+    required: ["slug"],
+    unknownKeyword: true,
+  };
+  const result = validateSchema(schema, { slug: "ok" });
+  assert.equal(result.ok, false);
+  assert.match(result.error ?? "", /Invalid schema definition/i);
+});


### PR DESCRIPTION
## Summary
- add `mcp.methods` manifest flags for optional MCP methods
- implement optional handlers for `resources/templates/list`, `completion/complete`, and completion notifications
- advertise `capabilities.completions` only when completion support is enabled
- update manifest schema/docs and add coverage tests
- keep runtime default protocol at `2025-11-25` and strict schema validation behavior

## Testing
- `pnpm build`
- `pnpm test`

Closes #2
